### PR TITLE
First iteration of the crowdsale contract

### DIFF
--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -89,17 +89,17 @@ contract ZxcCrowdsale is Ownable {
    * @param _minimumWeiDeposit Minimum required deposit in wei.
    */
   constructor(address _walletAddress,
-              address _tokenAddress,
-              uint256 _startTimePresale,  // 1529971200: date -d '2018-06-26 00:00:00 UTC' +%s
-              uint256 _startTimeSaleWithBonus, // 1530662400: date -d '2018-07-04 00:00:00 UTC' +%s
-              uint256 _startTimeSaleNoBonus,  //1530748800: date -d '2018-07-05 00:00:00 UTC' +%s
-              uint256 _endTime,  // 1531872000: date -d '2018-07-18 00:00:00 UTC' +%s
-              uint256 _rate,  // 10000: 1 ETH = 10,000 ZXC
-              uint256 _crowdSaleZxcCap, // 250M
-              uint256 _bonusPresale,  // 10 (%)
-              uint256 _bonusSale,  // 5 (%)
-              uint256 _minimumWeiDeposit  // 1 ether;
-             )
+    address _tokenAddress,
+    uint256 _startTimePresale,  // 1529971200: date -d '2018-06-26 00:00:00 UTC' +%s
+    uint256 _startTimeSaleWithBonus, // 1530662400: date -d '2018-07-04 00:00:00 UTC' +%s
+    uint256 _startTimeSaleNoBonus,  //1530748800: date -d '2018-07-05 00:00:00 UTC' +%s
+    uint256 _endTime,  // 1531872000: date -d '2018-07-18 00:00:00 UTC' +%s
+    uint256 _rate,  // 10000: 1 ETH = 10,000 ZXC
+    uint256 _crowdSaleZxcCap, // 250M
+    uint256 _bonusPresale,  // 10 (%)
+    uint256 _bonusSale,  // 5 (%)
+    uint256 _minimumWeiDeposit  // 1 ether;
+  )
     public
   {
     //uint256 _decimalsMul;

--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -1,0 +1,278 @@
+pragma solidity ^0.4.24;
+
+import "@0xcert/ethereum-utils/contracts/math/SafeMath.sol";
+import "@0xcert/ethereum-utils/contracts/ownership/Ownable.sol";
+import "@0xcert/ethereum-zxc/contracts/tokens/Zxc.sol";
+
+
+/**
+ * @title ZXC crowdsale contract.
+ * @dev Crowdsale contract for distributing ZXC tokens.
+ */
+contract ZxcCrowdsale is Ownable {
+  using SafeMath for uint256;
+
+  /**
+   * Token being sold.
+   */
+  Zxc public token;
+
+  /**
+   * Start timestamps for the following stages (start dates are inclusive, end exclusive):
+   * - Token pre-sale with 10% bonus: 2018/06/26 - 2018/07/04
+   * - Token sale with 5% bonus: 2018/07/04 - 2018/07/05
+   * - Token sale with 0% bonus: 2018/07/05 - 2018/07/18
+   */
+  uint256 public startTimePresale;
+  uint256 public startTimeSaleWithBonus;
+  uint256 public startTimeSaleNoBonus;
+
+  uint256 public bonusPresale;
+  uint256 public bonusSale;
+
+  /**
+   * End timestamp to end the crowdsale.
+   */
+  uint256 public endTime;
+
+  /**
+   * Minimum required wei deposit.
+   */
+  uint256 public minimumWeiDeposit;
+
+  /**
+   * Crowdsale cap in ZXC.
+   */
+  uint256 public crowdSaleZxcCap;
+
+  /**
+   * Amount of ZXC tokens sold.
+   */
+  uint256 public zxcSold;
+
+  /**
+   * Address where funds are collected.
+   */
+  address public wallet;
+
+  /**
+   * How many token units buyer gets per wei.
+   */
+  uint256 public rate;
+
+  /**
+   * @dev An event which is triggered when tokens are bought.
+   * @param _from The address sending tokens.
+   * @param _to The address recieving tokens.
+   * @param _weiAmount Purchase amount in wei.
+   * @param _tokenAmount The amount of purchased tokens.
+   */
+  event TokenPurchase(
+    address indexed _from,
+    address indexed _to,
+    uint256 _weiAmount,
+    uint256 _tokenAmount
+  );
+
+  /**
+   * @dev Contract constructor.
+   * @param _walletAddress Address of the wallet which collects funds.
+   * @param _tokenAddress Address of the ZXC token contract.
+   * @param _startTimePresale Start time of presale stage.
+   * @param _startTimeSaleWithBonus Start time of public sale stage with bonus.
+   * @param _startTimeSaleNoBonus Start time of public sale stage with no bonus.
+   * @param _endTime Time when sale ends.
+   * @param _rate ZXC/ETH exchange rate.
+   * @param _crowdSaleZxcCap Number of ZXC tokens offered during the sale.
+   * @param _bonusPresale Bonus token percentage for presale.
+   * @param _bonusSale Bonus token percentage for public sale stage with bonus.
+   * @param _minimumWeiDeposit Minimum required deposit in wei.
+   */
+  constructor(address _walletAddress,
+              address _tokenAddress,
+              uint256 _startTimePresale,  // 1529971200: date -d '2018-06-26 00:00:00 UTC' +%s
+              uint256 _startTimeSaleWithBonus, // 1530662400: date -d '2018-07-04 00:00:00 UTC' +%s
+              uint256 _startTimeSaleNoBonus,  //1530748800: date -d '2018-07-05 00:00:00 UTC' +%s
+              uint256 _endTime,  // 1531872000: date -d '2018-07-18 00:00:00 UTC' +%s
+              uint256 _rate,  // 10000: 1 ETH = 10,000 ZXC
+              uint256 _crowdSaleZxcCap, // 250M
+              uint256 _bonusPresale,  // 10 (%)
+              uint256 _bonusSale,  // 5 (%)
+              uint256 _minimumWeiDeposit  // 1 ether;
+             )
+    public
+  {
+    //uint256 _decimalsMul;
+    uint256 _bonusDividend = 100; // 100%
+
+    require(_walletAddress != address(0));
+    require(_tokenAddress != address(0));
+    require(_tokenAddress != _walletAddress);
+
+    token = Zxc(_tokenAddress);
+
+    uint8 _tokenDecimals = token.decimals();
+    require(_tokenDecimals == 18);  // Sanity check.
+    //_decimalsMul = 10 ** uint256(_tokenDecimals);
+    wallet = _walletAddress;
+
+    require(_bonusPresale > 0);
+    require(_bonusSale > 0);
+    // 100% / _bonusPresale = bonusPresale -> bonus: tokenAmount / bonusPresale
+    bonusPresale = _bonusDividend.div(_bonusPresale);
+    // 100% / _bonusSale = bonusSale -> bonus: tokenAmount / bonusSale
+    bonusSale = _bonusDividend.div(_bonusSale);
+
+    require(_startTimePresale >= now);
+    require(_startTimeSaleWithBonus > _startTimePresale);
+    require(_startTimeSaleNoBonus > _startTimeSaleWithBonus);
+
+    startTimePresale = _startTimePresale;
+    startTimeSaleWithBonus = _startTimeSaleWithBonus;
+    startTimeSaleNoBonus = _startTimeSaleNoBonus;
+    endTime = _endTime;
+
+    require(_rate > 0);
+    rate = _rate;
+
+    require(_crowdSaleZxcCap > 0);
+    require(token.totalSupply() >= _crowdSaleZxcCap);
+
+    crowdSaleZxcCap = _crowdSaleZxcCap;
+    //crowdSaleZxcCap = _crowdSaleZxcCap.mul(_decimalsMul);
+    zxcSold = 0;
+
+    require(_minimumWeiDeposit > 0);
+    minimumWeiDeposit = _minimumWeiDeposit;
+  }
+
+  /**
+   * @dev Fallback function can be used to buy tokens.
+   */
+  function()
+    external
+    payable
+  {
+    buyTokens(msg.sender);
+  }
+
+  /**
+   * @dev Low level token purchase function.
+   * @param beneficiary Address which is buying tokens.
+   */
+  function buyTokens(address beneficiary)
+    public
+    payable
+  {
+    uint256 weiAmount = msg.value;
+
+    require(beneficiary != address(0));
+    require(weiAmount >= minimumWeiDeposit);
+
+    uint256 tokens = getTokenAmount(weiAmount);
+
+    require(zxcSold.add(tokens) <= crowdSaleZxcCap);
+    zxcSold = zxcSold.add(tokens);
+
+    forwardFunds();
+    require(token.transferFrom(token.owner(), beneficiary, tokens));
+    emit TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
+  }
+
+  /**
+   * @return true if crowdsale event has ended
+   */
+  function hasEnded()
+    external
+    view
+    returns (bool)
+  {
+    bool capReached = zxcSold >= crowdSaleZxcCap;
+    bool endTimeReached = now >= endTime;
+    return capReached || endTimeReached;
+  }
+
+  /**
+   * @dev Send wei to the collection wallet.
+   */
+  function forwardFunds()
+    internal
+  {
+    wallet.transfer(msg.value);
+  }
+
+  /**
+   * @dev Check if currently active period is private pre-sale with bonuses.
+   * @return bool
+   */
+  function isPrivatePresale()
+    internal
+    view
+    returns(bool)
+  {
+    if (now >= startTimePresale && now < startTimeSaleWithBonus)
+      return true;
+    else
+      return false;
+  }
+
+  /**
+   * @dev Check if currently active period is public sale with bonuses.
+   * @return bool
+   */
+  function isPublicSaleWithBonus()
+    internal
+    view
+    returns(bool)
+  {
+    if (now >= startTimeSaleWithBonus && now < startTimeSaleNoBonus)
+      return true;
+    else
+      return false;
+  }
+
+  /**
+   * @dev Check if currently active period is public sale without bonuses.
+   * @return bool
+   */
+  function isPublicSaleNoBonus()
+    internal
+    view
+    returns(bool)
+  {
+    if (now >= startTimeSaleNoBonus && now < endTime)
+      return true;
+    else
+      return false;
+  }
+
+
+  /**
+   * @dev Calculate amount of tokens for a given wei amount. Apply special bonuses depending on
+   * @param weiAmount Amount of wei for token purchase.
+   * the time of the purchase. If purchase is outside of every token sale window then revert.
+   * @return number of tokens per wei amount with possible token bonus
+   */
+  function getTokenAmount(uint256 weiAmount)
+    internal
+    view
+    returns(uint256)
+  {
+    uint256 tokens = weiAmount.mul(rate);
+    uint256 bonus = 0;
+
+    if (isPrivatePresale()) {
+      bonus = tokens.div(bonusPresale);
+    }
+    else if (isPublicSaleWithBonus()) {
+      bonus = tokens.div(bonusSale);
+    }
+    else if (isPublicSaleNoBonus()) {
+      // No bonus
+    }
+    else {
+      revert("Purchase outside of token sale time windows");
+    }
+    return tokens.add(bonus);
+  }
+}

--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -13,12 +13,12 @@ contract ZxcCrowdsale is Ownable {
   using SafeMath for uint256;
 
   /**
-   * Token being sold.
+   * @dev Token being sold.
    */
   Zxc public token;
 
   /**
-   * Start timestamps for the following stages (start dates are inclusive, end exclusive):
+   * @dev Start timestamps for the following stages (start dates are inclusive, end exclusive):
    * - Token pre-sale with 10% bonus: 2018/06/26 - 2018/07/04
    * - Token sale with 5% bonus: 2018/07/04 - 2018/07/05
    * - Token sale with 0% bonus: 2018/07/05 - 2018/07/18
@@ -31,32 +31,32 @@ contract ZxcCrowdsale is Ownable {
   uint256 public bonusSale;
 
   /**
-   * End timestamp to end the crowdsale.
+   * @dev End timestamp to end the crowdsale.
    */
   uint256 public endTime;
 
   /**
-   * Minimum required wei deposit.
+   * @dev Minimum required wei deposit.
    */
   uint256 public minimumWeiDeposit;
 
   /**
-   * Crowdsale cap in ZXC.
+   * @dev Crowdsale cap in ZXC.
    */
   uint256 public crowdSaleZxcCap;
 
   /**
-   * Amount of ZXC tokens sold.
+   * @dev Amount of ZXC tokens sold.
    */
   uint256 public zxcSold;
 
   /**
-   * Address where funds are collected.
+   * @dev Address where funds are collected.
    */
   address public wallet;
 
   /**
-   * How many token units buyer gets per wei.
+   * @dev How many token units buyer gets per wei.
    */
   uint256 public rate;
 

--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -102,7 +102,6 @@ contract ZxcCrowdsale is Ownable {
   )
     public
   {
-    //uint256 _decimalsMul;
     uint256 _bonusDividend = 100; // 100%
 
     require(_walletAddress != address(0));
@@ -113,7 +112,6 @@ contract ZxcCrowdsale is Ownable {
 
     uint8 _tokenDecimals = token.decimals();
     require(_tokenDecimals == 18);  // Sanity check.
-    //_decimalsMul = 10 ** uint256(_tokenDecimals);
     wallet = _walletAddress;
 
     require(_bonusPresale > 0);
@@ -139,7 +137,6 @@ contract ZxcCrowdsale is Ownable {
     require(token.totalSupply() >= _crowdSaleZxcCap);
 
     crowdSaleZxcCap = _crowdSaleZxcCap;
-    //crowdSaleZxcCap = _crowdSaleZxcCap.mul(_decimalsMul);
     zxcSold = 0;
 
     require(_minimumWeiDeposit > 0);

--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -169,6 +169,7 @@ contract ZxcCrowdsale is Ownable {
     require(beneficiary != address(0));
     require(weiAmount >= minimumWeiDeposit);
 
+    //NOTE: this reverts if NOT in any of the sale time periods!
     uint256 tokens = getTokenAmount(weiAmount);
 
     require(zxcSold.add(tokens) <= crowdSaleZxcCap);

--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -13,7 +13,9 @@ import "@0xcert/ethereum-zxc/contracts/tokens/Zxc.sol";
  *   - Token sale with 5% bonus: 2018/07/04 - 2018/07/05
  *   - Token sale with 0% bonus: 2018/07/05 - 2018/07/18
  */
-contract ZxcCrowdsale is Ownable {
+contract ZxcCrowdsale is
+  Ownable
+{
   using SafeMath for uint256;
 
   /**

--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -102,8 +102,6 @@ contract ZxcCrowdsale is Ownable {
   )
     public
   {
-    uint256 _bonusDividend = 100; // 100%
-
     require(_walletAddress != address(0));
     require(_tokenAddress != address(0));
     require(_tokenAddress != _walletAddress);
@@ -118,9 +116,9 @@ contract ZxcCrowdsale is Ownable {
     require(_bonusPresale > 0 && _bonusPresale <= 100);
     require(_bonusSale > 0 && _bonusSale <= 100);
     // 100% / _bonusPresale = bonusPresale -> bonus: tokenAmount / bonusPresale
-    bonusPresale = _bonusDividend.div(_bonusPresale);
+    bonusPresale = _bonusPresale;
     // 100% / _bonusSale = bonusSale -> bonus: tokenAmount / bonusSale
-    bonusSale = _bonusDividend.div(_bonusSale);
+    bonusSale = _bonusSale;
 
     require(_startTimePresale >= now);
     require(_startTimeSaleWithBonus > _startTimePresale);
@@ -261,10 +259,10 @@ contract ZxcCrowdsale is Ownable {
     uint256 bonus = 0;
 
     if (isPrivatePresale()) {
-      bonus = tokens.div(bonusPresale);
+      bonus = tokens.mul(bonusPresale).div(uint256(100)); // tokens *  bonus (%) / 100%
     }
     else if (isPublicSaleWithBonus()) {
-      bonus = tokens.div(bonusSale);
+      bonus = tokens.mul(bonusSale).div(uint256(100)); // tokens * bonus (%) / 100%
     }
     else if (isPublicSaleNoBonus()) {
       // No bonus

--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -8,6 +8,10 @@ import "@0xcert/ethereum-zxc/contracts/tokens/Zxc.sol";
 /**
  * @title ZXC crowdsale contract.
  * @dev Crowdsale contract for distributing ZXC tokens.
+ * Start timestamps for the token sale stages (start dates are inclusive, end exclusive):
+ *   - Token presale with 10% bonus: 2018/06/26 - 2018/07/04
+ *   - Token sale with 5% bonus: 2018/07/04 - 2018/07/05
+ *   - Token sale with 0% bonus: 2018/07/05 - 2018/07/18
  */
 contract ZxcCrowdsale is Ownable {
   using SafeMath for uint256;
@@ -18,16 +22,29 @@ contract ZxcCrowdsale is Ownable {
   Zxc public token;
 
   /**
-   * @dev Start timestamps for the following stages (start dates are inclusive, end exclusive):
-   * - Token pre-sale with 10% bonus: 2018/06/26 - 2018/07/04
-   * - Token sale with 5% bonus: 2018/07/04 - 2018/07/05
-   * - Token sale with 0% bonus: 2018/07/05 - 2018/07/18
+   * @dev Start time of the presale.
    */
   uint256 public startTimePresale;
+
+  /**
+   * @dev Start time of the token sale with bonus.
+   */
   uint256 public startTimeSaleWithBonus;
+
+  /**
+   * @dev Start time of the token sale with no bonus.
+   */
   uint256 public startTimeSaleNoBonus;
 
+  /**
+   * @dev Presale bonus expressed as percentage integer (10% = 10).
+   */
   uint256 public bonusPresale;
+
+
+  /**
+   * @dev Token sale bonus expressed as percentage integer (10% = 10).
+   */
   uint256 public bonusSale;
 
   /**

--- a/contracts/crowdsale/ZxcCrowdsale.sol
+++ b/contracts/crowdsale/ZxcCrowdsale.sol
@@ -114,8 +114,9 @@ contract ZxcCrowdsale is Ownable {
     require(_tokenDecimals == 18);  // Sanity check.
     wallet = _walletAddress;
 
-    require(_bonusPresale > 0);
-    require(_bonusSale > 0);
+    // Bonus should be > 0% and <= 100%
+    require(_bonusPresale > 0 && _bonusPresale <= 100);
+    require(_bonusSale > 0 && _bonusSale <= 100);
     // 100% / _bonusPresale = bonusPresale -> bonus: tokenAmount / bonusPresale
     bonusPresale = _bonusDividend.div(_bonusPresale);
     // 100% / _bonusSale = bonusSale -> bonus: tokenAmount / bonusSale

--- a/test/crowdsale/ZxcCrowdsale.test.js
+++ b/test/crowdsale/ZxcCrowdsale.test.js
@@ -104,12 +104,12 @@ contract('crowdsale/ZxcCrowdsale', (accounts) => {
 
     it('constructor should set correct bonusPresale', async () => {
       const actualBonusPresale = await crowdsale.bonusPresale.call();
-      assert.strictEqual(actualBonusPresale.toString(), bonusPresaleDivisor.toString());
+      assert.strictEqual(actualBonusPresale.toString(), bonusPresale.toString());
     });
 
     it('constructor should set correct bonusSale', async () => {
       const actualBonusSale = await crowdsale.bonusSale.call();
-      assert.strictEqual(actualBonusSale.toString(), bonusSaleDivisor.toString());
+      assert.strictEqual(actualBonusSale.toString(), bonusSale.toString());
     });
 
     it('constructor should set correct minimumWeiDeposit', async () => {

--- a/test/crowdsale/ZxcCrowdsale.test.js
+++ b/test/crowdsale/ZxcCrowdsale.test.js
@@ -1,0 +1,583 @@
+const assertRevert = require('@0xcert/ethereum-utils/test/helpers/assertRevert');
+const { advanceBlock } = require('../helpers/advanceToBlock');
+const { increaseTime, increaseTimeTo, duration } = require('../helpers/increaseTime');
+const latestTime = require('../helpers/latestTime');
+const ether = require('../helpers/ether');
+
+const BigNumber = web3.BigNumber;
+
+const ZxcCrowdsale = artifacts.require('ZxcCrowdsale');
+const ZxcCrowdsaleTestable = artifacts.require('../mocks/ZxcCrowdsaleTestable.sol');
+const ZxcBigDecimals = artifacts.require('../mocks/ZxcBigDecimals.sol');
+const Zxc = artifacts.require('@0xcert/ethereum-zxc/contracts/tokens/Zxc.sol');
+
+
+contract('crowdsale/ZxcCrowdsale', (accounts) => {
+  const decimalsMul = new BigNumber('1e+18');  // 10 ** 18
+  const rate = new BigNumber(10000);  // 1 ETH = 10,000 ZXC
+  const crowdSaleZxcCap = new BigNumber(250000001).mul(decimalsMul);  // 250M + 1, 18 decimals
+  const minimumWeiDeposit = ether(1);
+  let startTimePresale;
+  let startTimeSaleWithBonus;
+  let startTimeSaleNoBonus;
+  let endTime;
+
+  const bonusDividend = new BigNumber(100);  // 100%
+  const bonusPresale = new BigNumber(10);  // 10%
+  // 100% / 10% = 10 <-- which we use to calc bonus: tokenAmount / 10
+  const bonusPresaleDivisor = bonusDividend.div(bonusPresale);
+
+  const bonusSale = new BigNumber(5);  // 5%
+  // 100% / 20% = 5 <-- which we use to calc bonus: tokenAmount / 5
+  const bonusSaleDivisor = bonusDividend.div(bonusSale);
+
+  const crowdsaleOwner = accounts[1];
+  const tokenOwner = accounts[2];
+  const wallet = accounts[3];
+  const buyerOne = accounts[4];
+  const buyerTwo = accounts[5];
+  const _tester = accounts[6];  // tester should never be the default account!
+
+  let token;
+  let crowdsale;
+
+  before(async () => {
+    // Advance to the next block to correctly read time in the solidity "now"
+    // function interpreted by testrpc
+    await advanceBlock();
+  });
+
+  describe('ZxcCrowdsale constructor', function() {
+    before(async () => {
+      startTimePresale = latestTime() + duration.hours(1);
+      startTimeSaleWithBonus = latestTime() + duration.hours(5);
+      startTimeSaleNoBonus = latestTime() + duration.hours(8);
+      endTime = latestTime() + duration.hours(12);
+    });
+
+    beforeEach(async () => {
+      token = await Zxc.new({from: tokenOwner});
+      crowdsale = await ZxcCrowdsale.new(wallet,
+                                        token.address,
+                                        startTimePresale,
+                                        startTimeSaleWithBonus,
+                                        startTimeSaleNoBonus,
+                                        endTime,
+                                        rate,
+                                        crowdSaleZxcCap,
+                                        bonusPresale,
+                                        bonusSale,
+                                        minimumWeiDeposit,
+                                        {from: crowdsaleOwner});
+    });
+
+    it('time stages should be correct and in the right order', async () => {
+      const actualPresaleTime = await crowdsale.startTimePresale.call();
+      const actualSaleWithBonusTime = await crowdsale.startTimeSaleWithBonus.call();
+      const actualSaleNoBonusTime = await crowdsale.startTimeSaleNoBonus.call();
+      const actualEndTime = await crowdsale.endTime.call();
+      assert.ok(actualPresaleTime < actualSaleWithBonusTime < actualSaleNoBonusTime < actualEndTime);
+      assert.strictEqual(actualPresaleTime.toNumber(), startTimePresale);
+      assert.strictEqual(actualSaleWithBonusTime.toNumber(), startTimeSaleWithBonus);
+      assert.strictEqual(actualSaleNoBonusTime.toNumber(), startTimeSaleNoBonus);
+      assert.strictEqual(actualEndTime.toNumber(), endTime);
+    });
+
+    it('constructor should set correct wallet address', async () => {
+      assert.strictEqual(await crowdsale.wallet.call(), wallet);
+    });
+
+    it('constructor should set correct token address', async () => {
+      assert.strictEqual(await crowdsale.token.call(), token.address);
+    });
+
+    it('constructor should set correct rate', async () => {
+      const actualRate = await crowdsale.rate.call();
+      //assert.strictEqual(actualRate.toString(), rate.mul(decimalsMul).toString());
+      assert.strictEqual(actualRate.toString(), rate.toString());
+    });
+
+    it('constructor should set correct crowdSaleZxcCap', async () => {
+      const actualCap = await crowdsale.crowdSaleZxcCap.call();
+      assert.strictEqual(actualCap.toString(), crowdSaleZxcCap.toString());
+    });
+
+    it('constructor should set correct bonusPresale', async () => {
+      const actualBonusPresale = await crowdsale.bonusPresale.call();
+      assert.strictEqual(actualBonusPresale.toString(), bonusPresaleDivisor.toString());
+    });
+
+    it('constructor should set correct bonusSale', async () => {
+      const actualBonusSale = await crowdsale.bonusSale.call();
+      assert.strictEqual(actualBonusSale.toString(), bonusSaleDivisor.toString());
+    });
+
+    it('constructor should set correct minimumWeiDeposit', async () => {
+      const actualMinDeposit = await crowdsale.minimumWeiDeposit.call();
+      assert.strictEqual(actualMinDeposit.toString(), minimumWeiDeposit.toString());
+    });
+
+    it('constructor should set correct zxcSold value', async () => {
+      const actualTokensSold = await crowdsale.zxcSold.call();
+      assert.strictEqual(actualTokensSold.toString(), new BigNumber(0).toString());
+    });
+
+    it('constructor should fail with start time in the past', async () => {
+      const firstStageStartPast = latestTime() - duration.weeks(1);
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          token.address,
+                                          firstStageStartPast,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+    it('constructor should fail with wallet address set to 0', async () => {
+      await assertRevert(ZxcCrowdsale.new(0,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should set correct wallet address', async () => {
+      const _crowdsale = await ZxcCrowdsale.new(wallet,
+                                                token.address,
+                                                startTimePresale,
+                                                startTimeSaleWithBonus,
+                                                startTimeSaleNoBonus,
+                                                endTime,
+                                                rate,
+                                                crowdSaleZxcCap,
+                                                bonusPresale,
+                                                bonusSale,
+                                                minimumWeiDeposit);
+      assert.strictEqual(await _crowdsale.wallet.call(), wallet);
+    });
+
+    it('constructor should fail with token address set to 0', async () => {
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          0,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should fail if wallet address equals token address', async () => {
+      await assertRevert(ZxcCrowdsale.new(token.address,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should fail if bonusPresale == 0', async () => {
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          0,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should fail if bonusSale == 0', async () => {
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          0,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should fail with rate set to zero', async () => {
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          0,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should fail if token decimals != 18', async () => {
+      let _token = await ZxcBigDecimals.new({from: tokenOwner});
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          _token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should fail with zero crowdsale cap', async () => {
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          0,
+                                          bonusPresale,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should fail with too low minimumWeiDeposit', async () => {
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          bonusSale,
+                                          0));
+    });
+  });
+
+  describe('ZxcCrowdsale helper functions', function() {
+    beforeEach(async () => {
+      // We need to restart start times for each test or EVM will fail spectacularly.
+      startTimePresale = latestTime() + duration.hours(1);
+      startTimeSaleWithBonus = latestTime() + duration.hours(5);
+      startTimeSaleNoBonus = latestTime() + duration.hours(8);
+      endTime = latestTime() + duration.hours(12);
+
+      token = await Zxc.new({from: tokenOwner});
+      crowdsale = await ZxcCrowdsaleTestable.new(wallet,
+                                                 token.address,
+                                                 startTimePresale,
+                                                 startTimeSaleWithBonus,
+                                                 startTimeSaleNoBonus,
+                                                 endTime,
+                                                 rate,
+                                                 crowdSaleZxcCap,
+                                                 bonusPresale,
+                                                 bonusSale,
+                                                 minimumWeiDeposit,
+                                                 _tester,
+                                                 {from: crowdsaleOwner});
+    });
+
+    it('hasEnded should return false if crowdsale not started, cap not reached', async () => {
+      assert.strictEqual(await crowdsale.hasEnded(), false);
+    });
+
+    it('hasEnded should return false if crowdsale in private sale stage, cap not reached', async () => {
+      await increaseTimeTo(startTimePresale + duration.seconds(30));
+      assert.strictEqual(await crowdsale.hasEnded(), false);
+    });
+
+    it('hasEnded should return false if in crowdsale in bonus stage, cap not reached', async () => {
+      await increaseTimeTo(startTimeSaleWithBonus + duration.seconds(30));
+      assert.strictEqual(await crowdsale.hasEnded(), false);
+    });
+
+    it('hasEnded should return false if in crowdsale in no bonus stage, cap not reached', async () => {
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+      assert.strictEqual(await crowdsale.hasEnded(), false);
+    });
+
+    it('hasEnded should return true if crowdsale time ran out, cap not reached', async () => {
+      await increaseTimeTo(endTime + duration.seconds(30));
+      assert.strictEqual(await crowdsale.hasEnded(), true);
+    });
+
+    it('hasEnded should return true if crowdsale reached the cap, end time not reached', async () => {
+      await increaseTimeTo(startTimePresale + duration.seconds(30));
+      crowdsale._testSetZxcSold(crowdSaleZxcCap, {from: _tester})
+      assert.strictEqual(await crowdsale.hasEnded(), true);
+    });
+
+    it('hasEnded should return true if crowdsale reached the cap and end time', async () => {
+      await increaseTimeTo(endTime + duration.seconds(30));
+      crowdsale._testSetZxcSold(crowdSaleZxcCap, {from: _tester})
+      assert.strictEqual(await crowdsale.hasEnded(), true);
+    });
+
+    it('isPrivatePresale should return true if in private sale stage', async () => {
+      await increaseTimeTo(startTimePresale + duration.seconds(30));
+      assert.strictEqual(await crowdsale.isPrivatePresaleWrapper(), true);
+    });
+
+    it('isPrivatePresale should return false if not in private sale stage', async () => {
+      // Test before we hit the stage
+      assert.strictEqual(await crowdsale.isPrivatePresaleWrapper(), false);
+      await increaseTimeTo(startTimeSaleWithBonus + duration.seconds(30));
+      assert.strictEqual(await crowdsale.isPrivatePresaleWrapper(), false);
+    });
+
+    it('isPublicSaleWithBonus should return true if in public bonus stage', async () => {
+      await increaseTimeTo(startTimeSaleWithBonus + duration.seconds(30));
+      assert.strictEqual(await crowdsale.isPublicSaleWithBonusWrapper(), true);
+    });
+
+    it('isPublicSaleWithBonus should return false if not in public bonus stage', async () => {
+      // Test before we hit the stage
+      assert.strictEqual(await crowdsale.isPublicSaleWithBonusWrapper(), false);
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+      assert.strictEqual(await crowdsale.isPublicSaleWithBonusWrapper(), false);
+    });
+
+    it('isPublicSaleNoBonus should return true if in public no bonus stage', async () => {
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+      assert.strictEqual(await crowdsale.isPublicSaleNoBonusWrapper(), true);
+    });
+
+    it('isPublicSaleNoBonus should return false if not in public no bonus stage', async () => {
+      // Test before we hit the stage
+      assert.strictEqual(await crowdsale.isPublicSaleNoBonusWrapper(), false);
+      await increaseTimeTo(endTime + duration.seconds(30));
+      assert.strictEqual(await crowdsale.isPublicSaleNoBonusWrapper(), false);
+    });
+
+    it('getTokenAmount should return correct num of tokens if in private presale stage', async () => {
+      await increaseTimeTo(startTimePresale + duration.seconds(30));
+      // 5.1 ETH = 51000 ZXC
+      // 10% bonus: 51000 / 10 = 5100 ZXC
+      // Total: 56100.0 ZXC
+      let weiAmount = ether(5.1);
+      let expectedTokens = weiAmount.mul(rate);
+      let expectedBonus =  expectedTokens.div(bonusPresaleDivisor);
+      let actualTokens = await crowdsale.getTokenAmountWrapper(weiAmount, {from: buyerOne});
+      assert.strictEqual(actualTokens.toString(), expectedTokens.add(expectedBonus).toString());
+      // Sanity check
+      assert.strictEqual(actualTokens.toString(), '5.61e+22');
+      assert.strictEqual(actualTokens.div(decimalsMul).toString(), '56100');
+    });
+
+    it('getTokenAmount should return correct num of tokens if in public bonus stage', async () => {
+      await increaseTimeTo(startTimeSaleWithBonus + duration.seconds(30));
+      // 7.192012 ETH = 71920.12 ZXC
+      // 5% bonus: 71920.12 / 20 = 3596.006 ZXC
+      // Total: 75516.126 ZXC
+      let weiAmount = ether(7.192012);
+      let expectedTokens = weiAmount.mul(rate);
+      let expectedBonus =  expectedTokens.div(bonusSaleDivisor);
+      let actualTokens = await crowdsale.getTokenAmountWrapper(weiAmount, {from: buyerOne});
+      assert.strictEqual(actualTokens.toString(),
+                         expectedTokens.add(expectedBonus).toString());
+      // Sanity check
+      assert.strictEqual(actualTokens.toString(), '7.5516126e+22');
+      assert.strictEqual(actualTokens.div(decimalsMul).toString(), '75516.126');
+    });
+
+    it('getTokenAmount should return correct num of tokens if in public no bonus stage', async () => {
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+      // 9.8639 ETH = 98639 ZXC
+      let weiAmount = ether(9.8639);
+      let expectedTokens = weiAmount.mul(rate);
+      let actualTokens = await crowdsale.getTokenAmountWrapper(weiAmount, {from: buyerOne});
+      assert.strictEqual(actualTokens.toString(),
+                         expectedTokens.toString());
+      // Sanity check
+      assert.strictEqual(actualTokens.toString(), '9.8639e+22');
+      assert.strictEqual(actualTokens.div(decimalsMul).toString(), '98639');
+    });
+
+    it('getTokenAmount should revert if sale has not started yet', async () => {
+      let weiAmount = ether(19.8);
+      await assertRevert(crowdsale.getTokenAmountWrapper(weiAmount, {from: buyerOne}));
+    });
+
+    it('getTokenAmount should revert if sale has ended', async () => {
+      await increaseTimeTo(endTime + duration.seconds(30));
+      let weiAmount = ether(19.8);
+      await assertRevert(crowdsale.getTokenAmountWrapper(weiAmount, {from: buyerOne}));
+    });
+
+    it('forwardFunds should send ether to wallet address', async () => {
+      let weiAmount = ether(1.2);
+      let initialBalance = await web3.eth.getBalance(wallet);
+      await crowdsale.forwardFundsWrapper({from: buyerOne, value: weiAmount});
+      let newBalance = await web3.eth.getBalance(wallet);
+      assert.strictEqual(newBalance.sub(initialBalance).toString(), ether(1.2).toString());
+    });
+  });
+
+  describe('ZxcCrowdsale purchase tokens', function() {
+    beforeEach(async () => {
+      // We need to restart start times for each test or EVM will fail spectacularly.
+      startTimePresale = latestTime() + duration.hours(1);
+      startTimeSaleWithBonus = latestTime() + duration.hours(5);
+      startTimeSaleNoBonus = latestTime() + duration.hours(8);
+      endTime = latestTime() + duration.hours(12);
+
+      token = await Zxc.new({from: tokenOwner});
+      crowdsale = await ZxcCrowdsaleTestable.new(wallet,
+                                                 token.address,
+                                                 startTimePresale,
+                                                 startTimeSaleWithBonus,
+                                                 startTimeSaleNoBonus,
+                                                 endTime,
+                                                 rate,
+                                                 crowdSaleZxcCap,
+                                                 bonusPresale,
+                                                 bonusSale,
+                                                 minimumWeiDeposit,
+                                                 _tester,
+                                                 {from: crowdsaleOwner});
+      // TODO(luka): this enables transfers for all. We need to enable it only for crowdsale
+      // contract.
+      await token.enableTransfer({from: tokenOwner});
+    });
+
+    it('buyTokens should purchase tokens', async () => {
+      let weiAmount = ether(11.05);
+      let expectedSoldTokens = weiAmount.mul(rate);
+      let startWalletBalance = await web3.eth.getBalance(wallet);
+
+      // Set crowdsale contract ZXC allowance
+      await token.approve(crowdsale.address, crowdSaleZxcCap, {from: tokenOwner});
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+
+      let { logs } = await crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount});
+      let actualBalance = await token.balanceOf(buyerOne);
+      // Buyer should get correct number of tokens
+      assert.equal(actualBalance.toString(), expectedSoldTokens.toString());
+      // Wallet should receive correct amount of wei
+      let endWalletBalance = await web3.eth.getBalance(wallet);
+      assert.strictEqual(endWalletBalance.sub(startWalletBalance).toString(), weiAmount.toString());
+      // Counter for sold ZXC should be increased
+      let zxcSold = await crowdsale.zxcSold.call()
+      assert.strictEqual(zxcSold.toString(), expectedSoldTokens.toString());
+
+      let event = logs.find(e => e.event === 'TokenPurchase');
+      assert.notEqual(event, undefined);
+    });
+
+    it('buyTokens should fail purchasing tokens if beneficiary address is 0', async () => {
+      let weiAmount = ether(7.03);
+      // Set crowdsale contract ZXC allowance
+      await token.approve(crowdsale.address, crowdSaleZxcCap, {from: tokenOwner});
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+
+      await assertRevert(crowdsale.buyTokens(0, {from: buyerOne, value: weiAmount}));
+    });
+
+    it('buyTokens should fail purchasing tokens if ether amount is less than minimum deposit', async () => {
+      let weiAmount = ether(0.03);
+      // Set crowdsale contract ZXC allowance
+      await token.approve(crowdsale.address, crowdSaleZxcCap, {from: tokenOwner});
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+
+      await assertRevert(crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount}));
+    });
+
+    it('buyTokens should purchase tokens for minimum deposit amount', async () => {
+      let weiAmount = ether(1);
+      let expectedTokens = weiAmount.mul(rate);
+
+      // Set crowdsale contract ZXC allowance
+      await token.approve(crowdsale.address, crowdSaleZxcCap, {from: tokenOwner});
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+
+      await crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount});
+      let actualTokens = await token.balanceOf(buyerOne);
+      assert.strictEqual(actualTokens.toString(), expectedTokens.toString());
+    });
+
+    it('buyTokens should purchase tokens if sold token amount hits crowdsale cap', async () => {
+      let weiAmount = ether(3);
+      let crowdsaleCap = ether(3).mul(rate);
+      let expectedTokens = weiAmount.mul(rate);
+
+      // Set crowdsale contract ZXC allowance
+      await token.approve(crowdsale.address, crowdsaleCap, {from: tokenOwner});
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+
+      await crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount});
+      let actualTokens = await token.balanceOf(buyerOne);
+      assert.strictEqual(actualTokens.toString(), expectedTokens.toString());
+    });
+
+    it('buyTokens should fail purchasing if sold token amount goes over crowdsale cap', async () => {
+      let weiAmount = ether(3.1);
+      let crowdsaleCap = ether(3).mul(rate);
+
+      // Set crowdsale contract ZXC allowance
+      await token.approve(crowdsale.address, crowdsaleCap, {from: tokenOwner});
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+
+      await assertRevert(crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount}));
+    });
+
+    it('buyTokens should fail purchasing tokens if transferFrom fails', async () => {
+      let weiAmount = ether(2.1);
+
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+
+      // Crowdsale ZXC allowance not set, transferFrom fails
+      await assertRevert(crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount}));
+    });
+
+    it('fallback function should purchase tokens', async () => {
+      let weiAmount = ether(8.05113);
+      let expectedSoldTokens = weiAmount.mul(rate);
+      let startWalletBalance = await web3.eth.getBalance(wallet);
+
+      // Set crowdsale contract ZXC allowance
+      await token.approve(crowdsale.address, crowdSaleZxcCap, {from: tokenOwner});
+      await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
+
+      let { logs } = await crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount});
+      let actualBalance = await token.balanceOf(buyerOne);
+      // Buyer should get correct number of tokens
+      assert.equal(actualBalance.toString(), expectedSoldTokens.toString());
+      // Wallet should receive correct amount of wei
+      let endWalletBalance = await web3.eth.getBalance(wallet);
+      assert.strictEqual(endWalletBalance.sub(startWalletBalance).toString(), weiAmount.toString());
+      // Counter for sold ZXC should be increased
+      let zxcSold = await crowdsale.zxcSold.call()
+      assert.strictEqual(zxcSold.toString(), expectedSoldTokens.toString());
+
+      let event = logs.find(e => e.event === 'TokenPurchase');
+      assert.notEqual(event, undefined);
+    });
+
+  });
+});

--- a/test/crowdsale/ZxcCrowdsale.test.js
+++ b/test/crowdsale/ZxcCrowdsale.test.js
@@ -207,6 +207,20 @@ contract('crowdsale/ZxcCrowdsale', (accounts) => {
                                           minimumWeiDeposit));
     });
 
+    it('constructor should fail if bonusPresale > 100', async () => {
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          101,
+                                          bonusSale,
+                                          minimumWeiDeposit));
+    });
+
     it('constructor should fail if bonusSale == 0', async () => {
       await assertRevert(ZxcCrowdsale.new(wallet,
                                           token.address,
@@ -218,6 +232,20 @@ contract('crowdsale/ZxcCrowdsale', (accounts) => {
                                           crowdSaleZxcCap,
                                           bonusPresale,
                                           0,
+                                          minimumWeiDeposit));
+    });
+
+    it('constructor should fail if bonusSale > 100', async () => {
+      await assertRevert(ZxcCrowdsale.new(wallet,
+                                          token.address,
+                                          startTimePresale,
+                                          startTimeSaleWithBonus,
+                                          startTimeSaleNoBonus,
+                                          endTime,
+                                          rate,
+                                          crowdSaleZxcCap,
+                                          bonusPresale,
+                                          101,
                                           minimumWeiDeposit));
     });
 

--- a/test/crowdsale/ZxcCrowdsale.test.js
+++ b/test/crowdsale/ZxcCrowdsale.test.js
@@ -592,7 +592,7 @@ contract('crowdsale/ZxcCrowdsale', (accounts) => {
       await token.approve(crowdsale.address, crowdSaleZxcCap, {from: tokenOwner});
       await increaseTimeTo(startTimeSaleNoBonus + duration.seconds(30));
 
-      let { logs } = await crowdsale.buyTokens(buyerOne, {from: buyerOne, value: weiAmount});
+      let { logs } = await crowdsale.sendTransaction({from: buyerOne, value: weiAmount});
       let actualBalance = await token.balanceOf(buyerOne);
       // Buyer should get correct number of tokens
       assert.equal(actualBalance.toString(), expectedSoldTokens.toString());

--- a/test/crowdsale/ZxcCrowdsale.test.js
+++ b/test/crowdsale/ZxcCrowdsale.test.js
@@ -495,7 +495,7 @@ contract('crowdsale/ZxcCrowdsale', (accounts) => {
     });
 
     it('buyTokens should purchase tokens', async () => {
-      let weiAmount = ether(11.05);
+      let weiAmount = ether("3.333333333333333333");
       let expectedSoldTokens = weiAmount.mul(rate);
       let startWalletBalance = await web3.eth.getBalance(wallet);
 

--- a/test/helpers/advanceToBlock.js
+++ b/test/helpers/advanceToBlock.js
@@ -1,0 +1,22 @@
+exports.advanceBlock  = function () {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync({
+      jsonrpc: '2.0',
+      method: 'evm_mine',
+      id: Date.now(),
+    }, (err, res) => {
+      return err ? reject(err) : resolve(res);
+    });
+  });
+}
+
+// Advances the block number so that the last mined block is `number`.
+exports.advanceToBlock = async function (number) {
+  if (web3.eth.blockNumber > number) {
+    throw Error(`block number ${number} is in the past (current is ${web3.eth.blockNumber})`);
+  }
+
+  while (web3.eth.blockNumber < number) {
+    await advanceBlock();
+  }
+}

--- a/test/helpers/ether.js
+++ b/test/helpers/ether.js
@@ -1,0 +1,3 @@
+module.exports = function ether (n) {
+  return new web3.BigNumber(web3.toWei(n, 'ether'));
+}

--- a/test/helpers/increaseTime.js
+++ b/test/helpers/increaseTime.js
@@ -1,0 +1,48 @@
+const latestTime = require('./latestTime');
+
+// Increases testrpc time by the passed duration in seconds
+exports.increaseTime = function (duration) {
+  const id = Date.now();
+
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync({
+      jsonrpc: '2.0',
+      method: 'evm_increaseTime',
+      params: [duration],
+      id: id,
+    }, err1 => {
+      if (err1) return reject(err1);
+
+      web3.currentProvider.sendAsync({
+        jsonrpc: '2.0',
+        method: 'evm_mine',
+        id: id + 1,
+      }, (err2, res) => {
+        return err2 ? reject(err2) : resolve(res);
+      });
+    });
+  });
+}
+
+/**
+ * Beware that due to the need of calling two separate testrpc methods and rpc calls overhead
+ * it's hard to increase time precisely to a target point so design your test to tolerate
+ * small fluctuations from time to time.
+ *
+ * @param target time in seconds
+ */
+exports.increaseTimeTo = function (target) {
+  let now = latestTime();
+  if (target < now) throw Error(`Cannot increase current time(${now}) to a moment in the past(${target})`);
+  let diff = target - now;
+  return exports.increaseTime(diff);
+}
+
+exports.duration = Object.freeze({
+  seconds: function (val) { return val; },
+  minutes: function (val) { return val * this.seconds(60); },
+  hours: function (val) { return val * this.minutes(60); },
+  days: function (val) { return val * this.hours(24); },
+  weeks: function (val) { return val * this.days(7); },
+  years: function (val) { return val * this.days(365); },
+});

--- a/test/helpers/latestTime.js
+++ b/test/helpers/latestTime.js
@@ -1,0 +1,4 @@
+// Returns the time of the last mined block in seconds
+module.exports = function latestTime () {
+  return web3.eth.getBlock('latest').timestamp;
+}

--- a/test/mocks/ZxcBigDecimals.sol
+++ b/test/mocks/ZxcBigDecimals.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.24;
+
+import "@0xcert/ethereum-zxc/contracts/tokens/Zxc.sol";
+import "@0xcert/ethereum-utils/contracts/math/SafeMath.sol";
+
+
+contract ZxcBigDecimals is Zxc {
+  using SafeMath for uint256;
+
+  constructor()
+  Zxc()
+  public
+  {
+    tokenDecimals = 50;
+  }
+}

--- a/test/mocks/ZxcCrowdsaleTestable.sol
+++ b/test/mocks/ZxcCrowdsaleTestable.sol
@@ -1,0 +1,124 @@
+pragma solidity ^0.4.24;
+
+import "../../contracts/crowdsale/ZxcCrowdsale.sol";
+
+
+/**
+  * @title This contract adds additional test functions to the crowdsale contract.
+  * Used to properly test internal functions and contract states which would otherwise be
+  * hard to set up. There are two types of functions; one change contract state and other
+  * visibility of contract functions. Both have their own naming pattern:
+  * 1. Ones that change values of contract variables: `_testSet<variableName>()`.
+  * 2. Ones that change function visibility: `<functionName>Wrapper()`.
+  */
+contract ZxcCrowdsaleTestable is ZxcCrowdsale {
+  /**
+   * @dev Tester's address who gains access to super powers.
+   */
+  address public contractTesterAddr;
+
+  /**
+   * @dev check tester's address who is the only one allowed to call _test functions
+   */
+  modifier onlyTester() {
+    require(msg.sender == contractTesterAddr);
+    _;
+  }
+
+  constructor(address _walletAddress,
+              address _tokenAddress,
+              uint256 _startTimePresale,
+              uint256 _startTimeSaleWithBonus,
+              uint256 _startTimeSaleNoBonus,
+              uint256 _endTime,
+              uint256 _rate,
+              uint256 _crowdSaleZxcCap,
+              uint256 _bonusPresale,
+              uint256 _bonusSale,
+              uint256 _minimumWeiDeposit,
+              address _contractTesterAddr
+             )
+    ZxcCrowdsale(
+      _walletAddress,
+      _tokenAddress,
+      _startTimePresale,
+      _startTimeSaleWithBonus,
+      _startTimeSaleNoBonus,
+      _endTime,
+      _rate,
+      _crowdSaleZxcCap,
+      _bonusPresale,
+      _bonusSale,
+      _minimumWeiDeposit
+    )
+    public
+  {
+    contractTesterAddr = _contractTesterAddr;
+  }
+
+  /**
+   * @dev Sets zxcSold value.
+   * @param amount New amount.
+   */
+  function _testSetZxcSold(uint256 amount)
+    external
+  {
+    zxcSold = amount;
+  }
+
+  /**
+   * @dev Calls internal forwardFunds function.
+   */
+  function forwardFundsWrapper()
+    external
+    payable
+  {
+    super.forwardFunds();
+  }
+
+  /**
+   * @dev Modify visibility for internal isPrivatePresale function.
+   */
+  function isPrivatePresaleWrapper()
+    external
+    view
+    returns (bool)
+  {
+    return super.isPrivatePresale();
+  }
+
+  /**
+   * @dev Modify visibility for internal isPublicSaleWithBonus function.
+   */
+  function isPublicSaleWithBonusWrapper()
+    external
+    view
+    returns (bool)
+  {
+    return super.isPublicSaleWithBonus();
+  }
+
+  /**
+   * @dev Modify visibility for internal isPublicSaleNoBonus function.
+   */
+  function isPublicSaleNoBonusWrapper()
+    external
+    view
+    returns (bool)
+  {
+    return super.isPublicSaleNoBonus();
+  }
+
+  /**
+   * @dev Modify visibility for internal getTokenAmount function.
+   * @param weiAmount amount of wei
+   */
+  function getTokenAmountWrapper(uint256 weiAmount)
+    external
+    view
+    returns (uint256)
+  {
+    return super.getTokenAmount(weiAmount);
+  }
+
+}


### PR DESCRIPTION
This is first iteration with the base crowdsale contract logic. In the next iterations I'm going to add:

- [ ] Presale cap.
- [ ] Check for Xcert KYC token.
- [ ] ZXC update - we need superpowers to transfer tokens when transferts are disabled. 
- [ ] Remove minimum deposit for sale periods (keep it only for presale).